### PR TITLE
Patch for deb-pkg v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Features:
 * Support for STM32L1, SM32L4 option bytes write ([#596](https://github.com/stlink-org/stlink/pull/596), [#844](https://github.com/stlink-org/stlink/pull/844), [#847](https://github.com/stlink-org/stlink/pull/847))
 * Added CMAKEFLAGS and install target ([#804](https://github.com/stlink-org/stlink/pull/804), [#935](https://github.com/stlink-org/stlink/pull/935))
 * Support for STM32G4 ([#822](https://github.com/stlink-org/stlink/pull/822))
-* Add aliased SRAM2 region in the L496 memory map ([#824](https://github.com/stlink-org/stlink/pull/824))
+* Added aliased SRAM2 region in the L496 memory map ([#824](https://github.com/stlink-org/stlink/pull/824))
 * Improved support for STM32G0 ([#825](https://github.com/stlink-org/stlink/pull/825), [#850](https://github.com/stlink-org/stlink/pull/850), [#856](https://github.com/stlink-org/stlink/pull/856), [#857](https://github.com/stlink-org/stlink/pull/857))
 * Added postinst script with 'depmod -a' for 'make package' ([#845](https://github.com/stlink-org/stlink/pull/845), [#931](https://github.com/stlink-org/stlink/pull/931))
 * Calculate checksums for flash operations ([#862](https://github.com/stlink-org/stlink/pull/862), [#924](https://github.com/stlink-org/stlink/pull/924))
@@ -358,6 +358,7 @@ Chip support added for:
 * STM32F469/STM32F479 ([#345](https://github.com/stlink-org/stlink/pull/345), [#555](https://github.com/stlink-org/stlink/pull/555)) (Release v1.2.0)
 * STM32L1xx Cat.2 devices (Nicolas Schodet)
 * STM32L1xx (chip-ID 0x427) ([#152](https://github.com/stlink-org/stlink/pull/152), [#163](https://github.com/stlink-org/stlink/pull/163), [#165](https://github.com/stlink-org/stlink/pull/165)) (Release v1.0.0)
+* Added SIGINT handler for stlink cleanup ([#31](https://github.com/stlink-org/stlink/pull/31), [#135](https://github.com/stlink-org/stlink/pull/135)) (Release v1.0.0)
 
 Board support added for:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.4.2)
 cmake_policy(SET CMP0042 NEW)
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake/modules")
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -94,6 +94,13 @@ include_directories(${PROJECT_SOURCE_DIR}/include/stlink/tools)
 include_directories(src)
 include_directories(src/tools)                                                  ### TODO: Clean this up...
 
+## Set installation directory for header files
+set(STLINK_INCLUDE_PATH ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME} CACHE PATH "Main include install directory")
+
+## Subordinate CMakeLists for version config & header installation
+#add_subdirectory(inc)
+
+## Define source- and headerfiles for stlink library
 set(STLINK_HEADERS
         include/stlink.h
         include/stlink/backend.h
@@ -143,7 +150,7 @@ endif ()
 set(STLINK_LIBRARY_PATH ${CMAKE_INSTALL_LIBDIR} CACHE PATH "Main library install directory")
 
 # Set the environment variable LD_LIBRARY_PATH to point to /usr/local/lib (per default).
-execute_process (COMMAND bash -c "export LD_LIBRARY_PATH="${CMAKE_INSTALL_LIBDIR}" ")
+execute_process(COMMAND bash -c "export LD_LIBRARY_PATH=${CMAKE_INSTALL_LIBDIR}")
 
 
 ###
@@ -259,8 +266,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(STLINK_MODPROBED_DIR "/etc/modprobe.d" CACHE PATH "modprobe.d directory")
     install(FILES ${CMAKE_SOURCE_DIR}/config/modprobe.d/stlink_v1.conf DESTINATION ${STLINK_MODPROBED_DIR})
 
-    ## Install udev rules files to /etc/udev/rules.d/ (explicitly hardcoded)
-    set(STLINK_UDEV_RULES_DIR "/etc/udev/rules.d" CACHE PATH "udev rules directory")
+    ## Install udev rules files to /lib/udev/rules.d/ (explicitly hardcoded)
+    set(STLINK_UDEV_RULES_DIR "/lib/udev/rules.d" CACHE PATH "udev rules directory")
     file(GLOB RULES_FILES ${CMAKE_SOURCE_DIR}/config/udev/rules.d/*.rules)
     install(FILES ${RULES_FILES} DESTINATION ${STLINK_UDEV_RULES_DIR})
 endif ()

--- a/cmake/packaging/deb/changelog
+++ b/cmake/packaging/deb/changelog
@@ -1,5 +1,5 @@
-stlink (1.6.1) unstable; urgency=medium
+stlink (1.6.1+ds-1) unstable; urgency=medium
 
-  * Initial Debian-packaged Release.
+  * Initial cpack-based package release for Debian/Ubuntu
 
  -- Nightwalker-87 <stlink-org>  Mon, 01 Jun 2020 00:00:00 +0100

--- a/cmake/packaging/deb/changelog
+++ b/cmake/packaging/deb/changelog
@@ -1,49 +1,5 @@
-stlink (1.6.0+ds-1) unstable; urgency=medium
+stlink (1.6.1) unstable; urgency=medium
 
-  * Merge tag 'v1.6.0' into debian
-  * Bump Standards-Version to 4.5.0, no changes.
-  * Update libstlink1 symbols file for 1.6.0.
+  * Initial Debian-packaged Release.
 
- -- Luca Boccassi <bluca@debian.org>  Tue, 25 Feb 2020 22:08:33 +0000
-
-stlink (1.5.1+ds-2) unstable; urgency=medium
-
-  * Mark library packages as Multi-Arch: same.
-  * Apply cross.patch to fix cross-compiling the GUI. Thanks Helmut for the patch! (Closes: #941320)
-  * Vcs-Git: add -b debian
-  * Set Rules-Requires-Root: no
-  * Bump Standards-Version to 4.4.0
-
- -- Luca Boccassi <bluca@debian.org>  Sun, 29 Sep 2019 12:50:58 +0100
-
-stlink (1.5.1+ds-1) unstable; urgency=medium
-
-  * Merge tag 'v1.5.1' into debian. See upstream changelog for info:
-    https://github.com/stlink-org/stlink/releases/tag/v1.5.1
-  * Mark packages as linux-any, other systems not supported.
-
- -- Luca Boccassi <bluca@debian.org>  Fri, 28 Sep 2018 10:26:39 +0100
-
-stlink (1.5.0+ds-1) unstable; urgency=medium
-
-  * Upload to unstable. (Closes: #869421)
-
- -- Luca Boccassi <bluca@debian.org>  Fri, 16 Mar 2018 16:56:17 +0000
-
-stlink (1.4.0) unstable; urgency=low
-
- -- Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>  Sat, 01 Jul 2017 00:00:00 +0000
-
-stlink (1.3.1) unstable; urgency=low
-
- -- Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>  Sat, 25 Feb 2017 00:00:00 +0000
-
-stlink (1.3.0) unstable; urgency=low
-
- -- Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>  Sat, 28 Jan 2017 00:00:00 +0000
-
-stlink (1.2.1) unstable; urgency=low
-
-  * Initial Debian-Packaged Release.
-
- -- Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>  Sat, 09 Jul 2016 23:16:07 +0300
+ -- Nightwalker-87 <stlink-org>  Mon, 01 Jun 2020 00:00:00 +0100

--- a/cmake/packaging/deb/control
+++ b/cmake/packaging/deb/control
@@ -1,9 +1,10 @@
 Source: stlink
-Maintainer: Luca Bocassi <bluca@debian.org>
-Build-Depends: cmake, dh-cmake, debhelper (>= 9), libusb-1.0-0-dev, libgtk-3-dev
-Standards-Version: 4.1.3
-Section: electronics
 Priority: optional
+Maintainer: stlink-org
+Build-Depends: cmake, dh-cmake, debhelper (>= 9), libusb-1.0-0-dev, libgtk-3-dev
+Standards-Version: 4.5.0
+Rules-Requires-Root: no
+Section: electronics
 Homepage: https://github.com/stlink-org/stlink
 Vcs-Git: https://github.com/stlink-org/stlink.git
 Vcs-Browser: https://github.com/stlink-org/stlink

--- a/cmake/packaging/deb/copyright
+++ b/cmake/packaging/deb/copyright
@@ -1,9 +1,9 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: stlink
-Upstream-Contact: Luca Bocassi <bluca@debian.org>
+Upstream-Contact: Nightwalker-87 <stlink-org>
 Source: https://github.com/stlink-org/stlink
-Disclaimer:
-Comment:
+Files-Excluded: stlinkv1_macos_driver
+
 Files: *
 Copyright: 2011-2020 stlink-org
     Martin Capitanio [capnm]
@@ -11,7 +11,7 @@ Copyright: 2011-2020 stlink-org
     Jerry Jacobs [xor-gate]
     [Nightwalker-87]
     and many others...
-    A list of contributors can be found in "contributors.txt".
+    An extended list of contributors can be found in "contributors.txt".
 License: BSD-3-clause
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:

--- a/cmake/packaging/deb/rules
+++ b/cmake/packaging/deb/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 # See debhelper(7) (uncomment to enable)
 # output every command that modifies files on the build system.
-DH_VERBOSE = 1
+#DH_VERBOSE = 1
 
 # see EXAMPLES in dpkg-buildflags(1) and read /usr/share/dpkg/*
 DPKG_EXPORT_BUILDFLAGS = 1
@@ -15,5 +15,4 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-    -DLIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH) \
     -DSTLINK_UDEV_RULES_DIR='/lib/udev/rules.d'

--- a/cmake/packaging/rpm/changelog
+++ b/cmake/packaging/rpm/changelog
@@ -1,2 +1,2 @@
-* Mon Jun 01 2020 Vasiliy Glazov <vascom@fedoraproject.org> - 1.6.1
-- Initial RPM-packaged release
+* Mon Jun 01 2020 Nightwalker-87 <stlink-org> - 1.6.1
+- Initial cpack-based RPM package release

--- a/debian/changelog
+++ b/debian/changelog
@@ -44,7 +44,7 @@ stlink (1.5.1+ds-2) unstable; urgency=medium
 stlink (1.5.1+ds-1) unstable; urgency=medium
 
   * Merge tag 'v1.5.1' into debian. See upstream changelog for info:
-    https://github.com/texane/stlink/releases/tag/v1.5.1
+    https://github.com/stlink-org/stlink/releases/tag/v1.5.1
   * Mark packages as linux-any, other systems not supported.
 
  -- Luca Boccassi <bluca@debian.org>  Fri, 28 Sep 2018 10:26:39 +0100
@@ -55,131 +55,19 @@ stlink (1.5.0+ds-1) unstable; urgency=medium
 
  -- Luca Boccassi <bluca@debian.org>  Fri, 16 Mar 2018 16:56:17 +0000
 
-stlink (1.5.0) unstable; urgency=medium
-
-  [ Jerry Jacobs ]
-  * README.md: Update version badge to v1.4.0
-
-  [ Viallard Anthony ]
-  * Add support of STM32L496xx/4A6xx devices (#615)
-
-  [ rdlim ]
-  * Fix verification of flash error for STM32L496x device (#617) (#618)
-
-  [ dflogeras ]
-  * Add note about availability in Gentoo package manager (#622)
-
-  [ yaofei zheng ]
-  * update debian package version (#630)
-
-  [ Lyle Cheatham ]
-  * Minor formatting fix in FAQ section of README.md (#631)
-
-  [ Vasiliy Glazov ]
-  * README.md: Added information about Fedora and RedHat/CentOS packages.
-    (#635)
-  * Added LIB_INSTALL_DIR to correct libs install on 64-bit systems (#636)
-
-  [ Gwenhael Goavec-Merou ]
-  * fix write for microcontroler with RAM size less or equal to 32K (#637)
-
-  [ Mateusz Krawiec ]
-  * Fix memory map for stm32l496xx boards. (#639)
-
-  [ Rüdiger Fortanier ]
-  * Add unknown chip output (#641)
-
-  [ Slyshyk Oleksiy ]
-  * fix __FILE__ base name extraction,  #628 (#648)
-
-  [ texane ]
-  * STM32F72xx73xx support, from bob.feretich@rafresearch.com
-
-  [ Kirill Kolyshkin ]
-  * debian/triggers: add (to run ldconfig) (#664)
-
-  [ Slyshyk Oleksiy ]
-  * Try to fix #666 issue (#667)
-  * Try to fix 666 issue (#668)
-
-  [ Jerry Jacobs ]
-  * Update ChangeLog.md
-  * Update README.md
-
-  [ texane ]
-  * STM32F042K6 Nucleo-32 Board reported to work, by frank@bauernoeppel.de
-
-  [ Anatol Pomozov ]
-  * Update .version file to match release number (#670)
-
- -- Anatol Pomozov <anatol.pomozov@gmail.com>  Mon, 19 Feb 2018 11:00:29 -0800
-
-libstlink (1.4.0) unstable; urgency=low
-
-  * Major changes and added features
-    - Add support for STM32L452 target (#608)
-    - Initial support to compile with Microsoft Visual Studio 2017 (#602)
-    - Added support for flashing second bank on STM32F10x_XL (#592)
-    - Add support for STM32L011 target (#572)
-    - Allow building of debian package with CPack (@xor-gate)
-  * Updates and fixes
-    - Fix compilation with GCC 7 (#590)
-    - Skip GTK detection if we're cross-compiling (#588)
-    - Fix possible memory leak (#570)
-    - Fix building with mingw64 (#569, #610)
-    - Update libusb to 1.0.21 for Windows (#562)
-    - Fixing low-voltage flashing on STM32F7 parts. (#567)
-    - Update libusb to 1.0.21 for Windows (#562)
+stlink (1.4.0) unstable; urgency=low
 
  -- Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>  Sat, 01 Jul 2017 00:00:00 +0000
 
-libstlink (1.3.1) unstable; urgency=low
-
-  * Major changes and added features:
-    - Add preliminary support for STM32L011 to see it after probe (chipid 0x457) (@xor-gate)
-    - Strip full paths to source files in log (commit #2c0ab7f)
-    - Add support for STM32F413 target (#549)
-    - Add support for Semihosting SYS_READC (#546)
-  * Updates and fixes:
-    - Update documentation markdown files
-    - Compilation fixes (#552)
-    - Fix compilation when path includes spaces (#561)
+stlink (1.3.1) unstable; urgency=low
 
  -- Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>  Sat, 25 Feb 2017 00:00:00 +0000
 
-libstlink (1.3.0) unstable; urgency=low
-
-  * Major changes and added features:
-    - Deprecation of autotools (autoconf, automake) (@xor-gate)
-    - Removal of undocumented st-term utility, which is now replaced by st-util ARM semihosting feature (#3fd0f09)
-    - Add support for native debian packaging (#444, #485)
-    - Add intel hex file reading for st-flash (#459)
-    - Add --reset command to st-flash (#505)
-    - Support serial numbers argument for st-util and st-flash for multi-programmer setups (#541)
-    - Add kill ('k') command to gdb-server for st-util (#9804416)
-    - Add manpages (generated with pandoc from Markdown) (#464)
-    - Rewrite commandline parsing for st-flash (#459)
-    - Add support for ARM semihosting to st-util (#454, #455)
-  * Chip support added for:
-    - STM32L432 (#501)
-    - STM32F412 (#538)
-    - STM32F410 (#9c635e4)
-    - Add memory map for STM32F401XE (#460)
-    - L0x Category 5 devices (#406)
-    - Add L0 Category 2 device (chip id: 0x425) (#72b8e5e)
-  * Updates and fixes:
-    - Fixed STM32F030 erase error (#442)
-    - Fixed Cygwin build (#68b0f3b)
-    - Reset flash mass erase (MER) bit after mass erase for safety (#489)
-    - Fix memory map for STM32F4 (@zulusw)
-    - Fix STM32L-problem with flash loader (issue #390) (Tom de Boer)
-    - st-util don't read target voltage on startup as it crashes STM32F100 (probably stlink/v1) (Greg Alexander)
-    - Do a JTAG reset prior to reading CPU information when processor is in deep sleep (@andyg24)
-    - Redesign of st-flash commandline options parsing (pull-request #459) (@dev26th)
+stlink (1.3.0) unstable; urgency=low
 
  -- Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>  Sat, 28 Jan 2017 00:00:00 +0000
 
-libstlink (1.2.1) unstable; urgency=low
+stlink (1.2.1) unstable; urgency=low
 
   * Initial Debian-Packaged Release.
 

--- a/debian/control
+++ b/debian/control
@@ -14,9 +14,7 @@ Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
 Depends: libstlink1 (= ${binary:Version}), ${misc:Depends}
-Description: OpenSource ST-Link tools replacement.
- Flashing tools for STMicroelectronics STM32VL and STM32L. The transport layers
- STLINKv1 and STLINKv2 are supported.
+Description: Open source STM32 MCU programming toolset.
  .
  This package contains the development files for stlink.
 
@@ -25,28 +23,22 @@ Section: libs
 Architecture: linux-any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: OpenSource ST-Link tools replacement.
- Flashing tools for STMicroelectronics STM32VL and STM32L. The transport layers
- STLINKv1 and STLINKv2 are supported.
+Description: Open source STM32 MCU programming toolset.
  .
  This package contains the shared library for stlink.
 
 Package: stlink-tools
 Architecture: linux-any
 Depends: libstlink1 (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
-Description: OpenSource ST-Link tools replacement.
- Flashing tools for STMicroelectronics STM32VL and STM32L. The transport layers
- STLINKv1 and STLINKv2 are supported.
+Description: Open source STM32 MCU programming toolset.
  .
- This package contains commandline utilities for stlink, and modprobe and
- udev rules.
+ This package contains commandline utilities for stlink, modprobe- and
+ udev-rules.
 
 Package: stlink-gui
 Architecture: linux-any
 Depends: libstlink1 (= ${binary:Version}), stlink-tools (= ${binary:Version}),
  ${shlibs:Depends}, ${misc:Depends}
-Description: OpenSource ST-Link tools replacement.
- Flashing tools for STMicroelectronics STM32VL and STM32L. The transport layers
- STLINKv1 and STLINKv2 are supported.
+Description: Open source STM32 MCU programming toolset.
  .
- This package contains a GUI tool for stlink.
+ This package contains a GUI for stlink.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,155 +1,37 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: stlink
-Upstream-Contact: Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>
+Upstream-Contact: Luca Boccassi <bluca@debian.org>
 Source: https://github.com/stlink-org/stlink
-Comment: Upstream tarball has been repackaged to remove binary OSX kernel
-         drivers that are of unknown license and of no use to Debian.
 Files-Excluded: stlinkv1_macos_driver
 
 Files: *
-Copyright: 2011-2018 agpanarin <agpanarin@gmail.com>
-           2011-2018 Alexey Cherevatenko <alecher@mail.ru>
-           2011-2018 Anatoli <dev@26th.net>
-           2011-2018 Andrea Mucignat <andrea@zulusw.com>
-           2011-2018 Andrew 'Necromant' Andrianov <andrew@ncrmnt.org>
-           2011-2018 Andrey Yurovsky <yurovsky@gmail.com>
-           2011-2018 Andy Isaacson <adi@onbeep.com>
-           2011-2018 Áron RADICS <raronkonektor@gmail.com>
-           2011-2018 A Sheaff <sheaff@traveler.eece.maine.edu>
-           2011-2018 Björn Hauffe <hauffe@gmail.com>
-           2011-2018 bob <bob@eleks.com>
-           2011-2018 Breton M. Saunders <bms20@camvine.com>
-           2011-2018 Bruno Dal Bo <bruno.dalbo@hp.com>
-           2011-2018 Burns <burns@fisher.cc>
-           2011-2018 Chris Dew <cmsdew@gmail.com>
-           2011-2018 Chris Hiszpanski <chiszp@gmail.com>
-           2011-2018 Chris Li <chris@tpx.lan>
-           2011-2018 Chris Samuelson <csamuelson@swingpal.com>
-           2011-2018 Christophe Levantis <Christophe.Levantis@cyantechnology.com>
-           2011-2018 Craig Lilley <cralilley@gmail.com>
-           2011-2018 dandev37 <dandev37@gmail.com>
-           2011-2018 Dan Hepler <dan.hepler@bionic-power.com>
-           2011-2018 Daniel Campoverde [alx741] <alx@sillybytes.net>
-           2011-2018 Daniel O'Connor <doconnor@gsoft.com.au>
-           2011-2018 Dave Flogeras <dflogeras@gmail.com>
-           2011-2018 Dave Murphy <davem@devkitpro.org>
-           2011-2018 Dave Vandervies <dj3vande@terse.ca>
-           2011-2018 Denis Fokin <foks.ua@gmail.com>
-           2011-2018 Denis Osterland <Denis.Osterland@diehl.com>
-           2011-2018 Dmitry Bravikov <bravikov@gmail.com>
-           2011-2018 Efe Can İçöz <efe@debian>
-           2011-2018 Ethan Zonca <ez@ethanzonca.com>
-           2011-2018 Fabien Chouteau <chouteau@adacore.com>
-           2011-2018 Fabien Le Mentec <texane@gmail.com>
-           2011-2018 fhars <fh+github@hars.de>
-           2011-2018 Friedrich Beckmann <friedrich.beckmann@gmx.de>
-           2011-2018 Geoffrey Brown <geoffreymbrown@gmail.com>
-           2011-2018 George Talusan <george.talusan@gmail.com>
-           2011-2018 Georg von Zengen <vonzengen@ibr.cs.tu-bs.de>
-           2011-2018 giuseppe barba <giuseppe.barba@gmail.com>
-           2011-2018 Greg Alexander <gitgreg@galexander.org>
-           2011-2018 Greg Meiste <w30289@motorola.com>
-           2011-2018 Hakkavélin <hakkavelin@braudrist.lan>
-           2011-2018 htk <htk@vdr.fritz.box>
-           2011-2018 Ian Griffiths <6thimage@gmail.com>
-           2011-2018 Jack Peel <jack.peel@synapse.com>
-           2011-2018 Jakub Tyszkowski <tyszja@gmail.com>
-           2011-2018 Jan Sarenik <janko@Lomidrevo.local>
-           2011-2018 Jean-Luc Béchennec <Jean-Luc.Bechennec@irccyn.ec-nantes.fr>
-           2011-2018 Jean-Marie Lemetayer <jeanmarie.lemetayer@gmail.com>
-           2011-2018 Jeff Kent <jakent@gmail.com>
-           2011-2018 Jeffrey Nelson <nelsonjm@macpod.net>
-           2011-2018 Jens Hoffmann <jehoffma@gmail.com>
-           2011-2018 Jerome Lambourg <lambourg@adacore.com>
-           2011-2018 Jerry Jacobs <jerry.jacobs@xor-gate.org>
-           2011-2018 Jim Paris <jim@jtan.com>
-           2011-2018 Jiří Netolický <netolicky@epos.cd.cz>
-           2011-2018 jnosky <codegrinder69@hotmail.com>
-           2011-2018 jnosky <Jerry@CGS_Office.(none)>
-           2011-2018 JohannesTaelman <johannes.taelman@gmail.com>
-           2011-2018 Jonas Danielsson <jonas.danielsson@lundinova.se>
-           2011-2018 Jonas Norling <jonas.norling@gmail.com>
-           2011-2018 Josh Bialkowski <josh@skyd.io>
-           2011-2018 Karl Palsson <karlp@tweak.net.au>
-           2011-2018 kevin <software@klystron.com>
-           2011-2018 Kyle Manna <kyle@kylemanna.com>
-           2011-2018 Lari Lehtomäki <lari@lehtomaki.fi>
-           2011-2018 le mentec fabien <fabien.lementec@imag.fr>
-           2011-2018 Martin Nowak <code@dawg.eu>
-           2011-2018 Matteo Collina <matteo.collina@gmail.com>
-           2011-2018 Max Chen <trlsmax@gmail.com>
-           2011-2018 Maxime Coquelin <mcoquelin.stm32@gmail.com>
-           2011-2018 Maxime Vincent <maxime.vincent@tass.be>
-           2011-2018 Michael Pratt <michael@pratt.im>
-           2011-2018 Michael Sparmann <theseven@gmx.net>
-           2011-2018 Mike Szczys <mike@jumptuck.com>
-           2011-2018 mlundinse <lundin@mlu.mine.nu>
-           2011-2018 mux <freelancer.c@gmail.com>
-           2011-2018 Ned Konz <ned@bike-nomad.com>
-           2011-2018 Nic McDonald <n.mcdonald83@gmail.com>
-           2011-2018 Nicolas Schodet <nico@ni.fr.eu.org>
-           2011-2018 Nikolay <halt.hammerzeit.at@gmail.com>
-           2011-2018 nullsub <chrisudeussen@gmail.com>
-           2011-2018 Olivier Croquette <olivier.croquette@nanotec.de>
-           2011-2018 Olivier Gay <ogay@logitech.com>
-           2011-2018 Onno Kortmann <onno@gmx.net>
-           2011-2018 orangeudav <orangeudav@gmail.com>
-           2011-2018 Pavel Kirienko <pavel.kirienko@gmail.com>
-           2011-2018 Pekka Nikander <pekka.nikander@senseg.com>
-           2011-2018 Pete <petiepooo@gmail.com>
-           2011-2018 Peter Zotov <whitequark@whitequark.org>
-           2011-2018 Petteri Aimonen <jpa@git.mail.kapsi.fi>
-           2011-2018 Piotr Haber <gluedig@gmail.com>
-           2011-2018 Rene Hopf <renehopf@mac.com>
-           2011-2018 Robin Kreis <r.kreis@uni-bremen.de>
-           2011-2018 Rob Spanton <rspanton@zepler.net>
-           2011-2018 Rytis Karpuska <rytis.karpuska@gmail.com>
-           2011-2018 Sean Simmons <sean.b.simmons@gmail.com>
-           2011-2018 Sergey Alirzaev <zl29ah@gmail.com>
-           2011-2018 Simon Wright <simon@pushface.org>
-           2011-2018 Stany MARCEL <stanypub@gmail.com>
-           2011-2018 Stefan Misik <mail@stefanmisik.eu>
-           2011-2018 Sven Wegener <sven.wegener@stealer.net>
-           2011-2018 Tectu <joel@unormal.org>
-           2011-2018 tekaikko <tuomo.kaikkonen@iki.fi>
-           2011-2018 texane <texane@gmail.com>
-           2011-2018 Theodore A. Roth <troth@openavr.org>
-           2011-2018 Thomas Gärtner <der@thotsch.com>
-           2011-2018 Tobias Badertscher <python@baerospace.ch>
-           2011-2018 Tom de Boer <tom@tomdeboer.nl>
-           2011-2018 Tristan Gingold <gingold@adacore.com>
-           2011-2018 Uli Köhler <ulikoehler@online.de>
-           2011-2018 Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
-           2011-2018 Vadim Kaushan <admin@disasm.info>
-           2011-2018 Vegard Storheil Eriksen <zyp@jvnv.net>
-           2011-2018 Viacheslav Dobromyslov <viacheslav@dobromyslov.ru>
-           2011-2018 Victor Mayoral Vilches <v.mayoralv@gmail.com>
-           2011-2018 Wojciech A. Koszek <wkoszek@freebsd.czest.pl>
-           2011-2018 Woodrow Douglass <wdouglass@carnegierobotics.com>
-           2011-2018 The "Capt'ns Missing Link" Authors.
+Copyright: 2011-2020 stlink-org
+    Martin Capitanio [capnm]
+    Fabien Le Mentec [texane]
+    Jerry Jacobs [xor-gate]
+    [Nightwalker-87]
+    and many others...
+    An extended list of contributors can be found in "contributors.txt".
 License: BSD-3-clause
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions
- are met:
- .
- * Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in
-   the documentation and/or other materials provided with the
-   distribution.
- * Neither the name of Intel Corporation nor the names of its
-   contributors may be used to endorse or promote products derived
-   from this software without specific prior written permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    .
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+    .
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/debian/libstlink-dev.install
+++ b/debian/libstlink-dev.install
@@ -2,4 +2,3 @@ usr/include/*
 usr/lib/*/lib*.a
 usr/lib/*/pkgconfig/*
 usr/lib/*/lib*.so
-

--- a/debian/stlink-gui.install
+++ b/debian/stlink-gui.install
@@ -1,4 +1,4 @@
 /usr/bin/stlink-gui
-/usr/bin/stlink-gui.ui /usr/share/stlink/
-/usr/share/stlink/applications/stlink-gui.desktop /usr/share/applications/
-/usr/share/stlink/icons/hicolor/scalable/apps/stlink-gui.svg /usr/share/icons/hicolor/scalable/apps/stlink-gui.svg
+/usr/share/stlink/stlink-gui.ui
+/usr/share/applications/stlink-gui.desktop
+/usr/share/icons/hicolor/scalable/apps/stlink-gui.svg

--- a/debian/stlink.pc.in
+++ b/debian/stlink.pc.in
@@ -3,7 +3,7 @@ includedir=${prefix}/include/stlink
 libdir=${prefix}/lib/@DEB_HOST_MULTIARCH@
 
 Name: stlink
-Description: Open source version of the STMicroelectronics Stlink Tools
+Description: Open source STM32 MCU programming toolset
 Version: @VERSION@
 Requires: libusb-1.0
 Libs: -L${libdir} -lstlink

--- a/doc/man/CMakeLists.txt
+++ b/doc/man/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach (manpage ${MANPAGES})
     endif ()
 
     if (f AND NOT WIN32)
-        install(FILES ${f} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/man/man1)
+        install(FILES ${f} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/man/man1)
         unset(f)
     endif ()
 endforeach ()

--- a/doc/version_support.md
+++ b/doc/version_support.md
@@ -68,7 +68,7 @@ NOTE: In order to use a STLINK/v1 programmer on macOS, versions 10.13, 10.14 or 
 
 ## Unsupported Operating Systems (as of Release v1.6.1)
 
-| Operating System | libusb<br />version | cmake<br />version | End of OS-Support | Notes |
+| Operating System | libusb<br />version | cmake<br />version | End of<br />OS-Support | Notes |
 | --- | --- | --- | --- | --- |
 | CentOS 7 | 1.0.21 | **2.8.12.2** | | named `libusbx`, but<br />`libusb`-codebase is used |
 | Debian 8 (Jessie) | 1.0.**19** | 3.**0.2** | Jun 2020 |

--- a/src/stlink-gui/CMakeLists.txt
+++ b/src/stlink-gui/CMakeLists.txt
@@ -13,11 +13,11 @@ if (NOT WIN32)
 
         # Install desktop application entry
         install(FILES stlink-gui.desktop
-                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/applications)
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 
         # Install icons
         install(FILES icons/stlink-gui.svg
-                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/icons/hicolor/scalable/apps)
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps)
 
         set(GUI_SOURCES gui.c gui.h)
 
@@ -30,9 +30,9 @@ if (NOT WIN32)
 
         ## stlink-gui
         add_executable(stlink-gui ${GUI_SOURCES})
-        install(FILES stlink-gui.ui DESTINATION ${CMAKE_INSTALL_BINDIR})
+        install(FILES stlink-gui.ui DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
         set_target_properties(stlink-gui PROPERTIES
-                COMPILE_DEFINITIONS STLINK_UI_DIR="${CMAKE_INSTALL_PREFIX}/bin")
+                COMPILE_DEFINITIONS STLINK_UI_DIR="${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}")
         target_link_libraries(stlink-gui ${STLINK_LIB_SHARED} ${SSP_LIB} ${GTK3_LDFLAGS})
         install(TARGETS stlink-gui DESTINATION ${CMAKE_INSTALL_BINDIR})
 


### PR DESCRIPTION
**stlink (1.6.1+ds-3)** 
  * Corrected install paths & changelog files
  * Corrected settings for deb pkg distribution

--> This patch addresses several points from a previous discussion and user feedback from the source project.

**Notes:**

1) Though it may not be a good practise in general, the changelog has been updated as some old entries have turned out to be wrong which have been corrected in the project's own changelog in the meanwhile. To avoid this in the future the Debian changelog should cover only package related changes, while the former will only focus on software-related changes (and will not list any distribution-related issues).
2) The Debian copyright file will no longer be updated with new contributors (there are too many and possibility of text formatting is very limited). To comply with the license terms we have added a separate listing within the project which is explicitly mentioned in the copyright file. This may be transferred to a markdown list in the future. For privacy reasons we also avoid to further disclose e-mail addresses publicly where possible.