### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: stlink
 Priority: optional
 Maintainer: Luca Boccassi <bluca@debian.org>
-Build-Depends: debhelper-compat (= 13), cmake (>= 3.4.2), libusb-1.0-0-dev, libgtk-3-dev
+Build-Depends: debhelper-compat (= 13), cmake, libusb-1.0-0-dev, libgtk-3-dev
 Standards-Version: 4.5.1
 Rules-Requires-Root: no
 Section: electronics


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/stlink/8d74889b-dac8-4071-90e5-a84312d5a1c6.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/05/7791707c7eefc65af2c41569373e3af5d4072d.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/1c/bc8232f4dfc9bf01c424f19ac9386076e20da0.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ab/03446eec6c8698cf457dd03bdc8403d13291b6.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/e4/2b2fe1aabc3dc7f2e9ee033e48ea835cedff01.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/f2/01a0dd863164903af68b81c987e27d604b972f.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/21/3f6f4d71115e1a82722f8665f87bcd94a9c53c.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/25/55914ae099ac41f539bc673509ac8d1fca3fc3.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ae/c09f7423111e0d74af4cfed04c0e3a3d842ad9.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b1/c8b8e87fd77dc475ff9ed7d427db3d086d2f30.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/cd/bbb29caae49c9bb43b37afb6e033d13761b58d.debug

No differences were encountered between the control files of package \*\*libstlink-dev\*\*

No differences were encountered between the control files of package \*\*libstlink1\*\*

No differences were encountered between the control files of package \*\*libstlink1-dbgsym\*\*

No differences were encountered between the control files of package \*\*stlink-gui\*\*
### Control files of package stlink-gui-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-2555914ae099ac41f539bc673509ac8d1fca3fc3-] {+e42b2fe1aabc3dc7f2e9ee033e48ea835cedff01+}

No differences were encountered between the control files of package \*\*stlink-tools\*\*
### Control files of package stlink-tools-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-213f6f4d71115e1a82722f8665f87bcd94a9c53c aec09f7423111e0d74af4cfed04c0e3a3d842ad9 b1c8b8e87fd77dc475ff9ed7d427db3d086d2f30 cdbbb29caae49c9bb43b37afb6e033d13761b58d-] {+057791707c7eefc65af2c41569373e3af5d4072d 1cbc8232f4dfc9bf01c424f19ac9386076e20da0 ab03446eec6c8698cf457dd03bdc8403d13291b6 f201a0dd863164903af68b81c987e27d604b972f+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/8d74889b-dac8-4071-90e5-a84312d5a1c6/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/8d74889b-dac8-4071-90e5-a84312d5a1c6/diffoscope)).
