### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: stlink
 Priority: optional
 Maintainer: Luca Boccassi <bluca@debian.org>
 Build-Depends: debhelper-compat (= 13), cmake, libusb-1.0-0-dev, libgtk-3-dev
-Standards-Version: 4.5.1
+Standards-Version: 4.6.2
 Rules-Requires-Root: no
 Section: electronics
 Homepage: https://github.com/stlink-org/stlink

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/stlink-org/stlink/issues
+Bug-Submit: https://github.com/stlink-org/stlink/issues/new
+Repository-Browse: https://github.com/stlink-org/stlink


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/17/a5c763af5ec113eb0e33a194675eecaf582b2f.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/63/9752dd2807fd0a4a8625dc87001a11d64a6519.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c7/290f962186aabe3add336a525ba764344b29ce.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/d7/226d2cb517ae193f0448fb2adaf4ae6fe608a1.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ef/6de3b0d2dadbd77118809ee4b0d98c6752ce7f.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/0d/10decab06c991d7665bd3f99ecab92d106909b.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/88/354557a8ca436200a75600f2cf77f362ea9f80.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/8a/522484e5d8201f8f2b4516688f1bbd6c6a673f.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/e6/1bdd5acaf89a23491f3d9aee1aea44b1869641.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/fa/f1559ca736fb8ae665e28549df5b891af87be1.debug

No differences were encountered between the control files of package \*\*libstlink-dev\*\*

No differences were encountered between the control files of package \*\*libstlink1\*\*

No differences were encountered between the control files of package \*\*libstlink1-dbgsym\*\*

No differences were encountered between the control files of package \*\*stlink-gui\*\*
### Control files of package stlink-gui-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-88354557a8ca436200a75600f2cf77f362ea9f80-] {+639752dd2807fd0a4a8625dc87001a11d64a6519+}

No differences were encountered between the control files of package \*\*stlink-tools\*\*
### Control files of package stlink-tools-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-0d10decab06c991d7665bd3f99ecab92d106909b 8a522484e5d8201f8f2b4516688f1bbd6c6a673f e61bdd5acaf89a23491f3d9aee1aea44b1869641 faf1559ca736fb8ae665e28549df5b891af87be1-] {+17a5c763af5ec113eb0e33a194675eecaf582b2f c7290f962186aabe3add336a525ba764344b29ce d7226d2cb517ae193f0448fb2adaf4ae6fe608a1 ef6de3b0d2dadbd77118809ee4b0d98c6752ce7f+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/534cf9bf-3750-4b19-acda-4cbef4330ac5/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/534cf9bf-3750-4b19-acda-4cbef4330ac5/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/stlink/534cf9bf-3750-4b19-acda-4cbef4330ac5.